### PR TITLE
Add Octrees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Introduced 3D `OctTree` with 3D AABB support and public exports.
+- Added octree unit tests covering insertion, intersection (AABB and generic), ray casting, and cleanup.
+- Extended 3D benchmarks to include OctTree alongside QuadTree and RTree for inserts and queries.
+- Added `RTree` implementation with bounding boxes, ray intersection queries, and comparisons against QuadTree.
+- New tests and benchmarks for RTree, including 2D/3D comparisons and ray-intersection scenarios.
+
 ## 0.5.0 - 2021-08-22
 
 ### Changed

--- a/benches/bench_compare_3d.rs
+++ b/benches/bench_compare_3d.rs
@@ -2,9 +2,10 @@ use criterion::{black_box, criterion_group, criterion_main, BatchSize, Benchmark
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 use space_partitioning::intersections::IntersectsWith;
+use space_partitioning::octree::{OctRect, OctTreeElement, AABB as AABB3};
 use space_partitioning::quadtree::{QuadRect, QuadTreeElement, AABB};
 use space_partitioning::rtree::{BoundingBox, RTree};
-use space_partitioning::QuadTree;
+use space_partitioning::{OctTree, QuadTree};
 
 const SPACE_MIN: i32 = 0;
 const SPACE_MAX: i32 = 1000;
@@ -12,6 +13,9 @@ const QUADTREE_DEPTH: u8 = 8;
 const QUADTREE_BUCKET: u32 = 16;
 const QUADTREE_MIN_CELL: u32 = 1;
 const Z_WEIGHT: f32 = 0.75;
+const OCTREE_DEPTH: u8 = 8;
+const OCTREE_BUCKET: u32 = 16;
+const OCTREE_MIN_CELL: u32 = 1;
 
 #[derive(Clone, Copy, Debug)]
 struct Sphere {
@@ -102,6 +106,33 @@ impl IntersectsWith<BoundingBox<f32, 3>> for Ray3 {
     }
 }
 
+impl IntersectsWith<AABB3> for Ray3 {
+    fn intersects_with(&self, other: &AABB3) -> bool {
+        let mut tmin = f32::NEG_INFINITY;
+        let mut tmax = f32::INFINITY;
+
+        let bounds = [
+            (other.min.x as f32, other.max.x as f32),
+            (other.min.y as f32, other.max.y as f32),
+            (other.min.z as f32, other.max.z as f32),
+        ];
+
+        for axis in 0..3 {
+            let t1 = (bounds[axis].0 - self.origin[axis]) * self.inv_dir[axis];
+            let t2 = (bounds[axis].1 - self.origin[axis]) * self.inv_dir[axis];
+            let (t1, t2) = if t1 < t2 { (t1, t2) } else { (t2, t1) };
+
+            tmin = tmin.max(t1);
+            tmax = tmax.min(t2);
+            if tmin > tmax {
+                return false;
+            }
+        }
+
+        tmax >= 0.0
+    }
+}
+
 struct BenchData {
     spheres: Vec<Sphere>,
     queries: Vec<Sphere>,
@@ -122,6 +153,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     for data in &datasets {
         bench_insert_rtree(&mut insert_group, data);
         bench_insert_quadtree(&mut insert_group, data);
+        bench_insert_octree(&mut insert_group, data);
     }
     insert_group.finish();
 
@@ -129,6 +161,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     for data in &datasets {
         bench_query_rtree(&mut query_group, data);
         bench_query_quadtree(&mut query_group, data);
+        bench_query_octree(&mut query_group, data);
     }
     query_group.finish();
 
@@ -136,6 +169,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     for data in &datasets {
         bench_query_rtree_ray(&mut ray_group, data);
         bench_query_quadtree_ray(&mut ray_group, data);
+        bench_query_octree_ray(&mut ray_group, data);
     }
     ray_group.finish();
 }
@@ -194,6 +228,35 @@ fn bench_insert_quadtree(
     );
 }
 
+fn bench_insert_octree(
+    group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    data: &BenchData,
+) {
+    let bounds = OctRect::new(
+        SPACE_MIN, SPACE_MIN, SPACE_MIN, SPACE_MAX, SPACE_MAX, SPACE_MAX,
+    );
+    group.bench_with_input(
+        BenchmarkId::new("octree", data.spheres.len()),
+        &data.spheres,
+        |b, spheres| {
+            b.iter_batched(
+                || spheres.clone(),
+                |spheres| {
+                    let mut tree =
+                        OctTree::new(bounds, OCTREE_DEPTH, OCTREE_BUCKET, OCTREE_MIN_CELL);
+                    for sphere in spheres {
+                        let aabb = sphere_to_octree_aabb(sphere);
+                        tree.insert(OctTreeElement::new(sphere.id, aabb))
+                            .expect("insert should work");
+                    }
+                    black_box(tree);
+                },
+                BatchSize::LargeInput,
+            );
+        },
+    );
+}
+
 fn bench_query_rtree(
     group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
     data: &BenchData,
@@ -220,6 +283,23 @@ fn bench_query_quadtree(
             let mut hits = 0usize;
             for query in &data.queries {
                 let aabb = sphere_to_quadtree_aabb(*query, data.z_range);
+                hits += tree.intersect_aabb(&aabb).len();
+            }
+            black_box(hits);
+        });
+    });
+}
+
+fn bench_query_octree(
+    group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    data: &BenchData,
+) {
+    let tree = build_octree(data);
+    group.bench_function(BenchmarkId::new("octree", data.spheres.len()), |b| {
+        b.iter(|| {
+            let mut hits = 0usize;
+            for query in &data.queries {
+                let aabb = sphere_to_octree_aabb(*query);
                 hits += tree.intersect_aabb(&aabb).len();
             }
             black_box(hits);
@@ -259,6 +339,22 @@ fn bench_query_quadtree_ray(
     });
 }
 
+fn bench_query_octree_ray(
+    group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    data: &BenchData,
+) {
+    let tree = build_octree(data);
+    group.bench_function(BenchmarkId::new("octree", data.spheres.len()), |b| {
+        b.iter(|| {
+            let mut hits = 0usize;
+            for ray in &data.rays_3d {
+                hits += tree.intersect_generic(ray).len();
+            }
+            black_box(hits);
+        });
+    });
+}
+
 fn build_rtree(data: &BenchData) -> RTree<f32, 3, 16, u32> {
     let mut tree: RTree<f32, 3, 16, u32> = RTree::default();
     for sphere in &data.spheres {
@@ -277,6 +373,23 @@ fn build_quadtree(data: &BenchData) -> QuadTree {
     for sphere in &data.spheres {
         let aabb = sphere_to_quadtree_aabb(*sphere, data.z_range);
         tree.insert(QuadTreeElement::new(sphere.id, aabb))
+            .expect("insert should work");
+    }
+    tree
+}
+
+fn build_octree(data: &BenchData) -> OctTree {
+    let mut tree = OctTree::new(
+        OctRect::new(
+            SPACE_MIN, SPACE_MIN, SPACE_MIN, SPACE_MAX, SPACE_MAX, SPACE_MAX,
+        ),
+        OCTREE_DEPTH,
+        OCTREE_BUCKET,
+        OCTREE_MIN_CELL,
+    );
+    for sphere in &data.spheres {
+        let aabb = sphere_to_octree_aabb(*sphere);
+        tree.insert(OctTreeElement::new(sphere.id, aabb))
             .expect("insert should work");
     }
     tree
@@ -353,6 +466,18 @@ fn sphere_to_quadtree_aabb(sphere: Sphere, z_range: (i32, i32)) -> AABB {
     let max_y = clamp_i32(sphere.center[1] + radius_scaled);
 
     AABB::new(min_x, min_y, max_x, max_y)
+}
+
+fn sphere_to_octree_aabb(sphere: Sphere) -> AABB3 {
+    let r = sphere.radius;
+    AABB3::new(
+        clamp_i32(sphere.center[0] - r),
+        clamp_i32(sphere.center[1] - r),
+        clamp_i32(sphere.center[2] - r),
+        clamp_i32(sphere.center[0] + r),
+        clamp_i32(sphere.center[1] + r),
+        clamp_i32(sphere.center[2] + r),
+    )
 }
 
 fn normalize_z(z: i32, z_range: (i32, i32)) -> f32 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,11 @@ extern crate core;
 
 pub mod intersections;
 pub mod interval_tree;
+pub mod octree;
 pub mod quadtree;
 pub mod rtree;
 
 pub use interval_tree::IntervalTree;
+pub use octree::OctTree;
 pub use quadtree::QuadTree;
 pub use rtree::{BoundingBox, DefaultTupleId, DimensionType, Extent, RTree, RTreeEntry};

--- a/src/octree.rs
+++ b/src/octree.rs
@@ -1,0 +1,143 @@
+mod aabb;
+mod centered_aabb;
+mod error;
+mod free_list;
+mod node;
+mod node_data;
+mod node_info;
+mod node_list;
+mod oct_rect;
+mod octants;
+#[allow(clippy::module_inception)]
+mod octree;
+mod octree_element;
+mod point;
+
+pub use aabb::AABB;
+pub use node_info::NodeInfo;
+pub use oct_rect::OctRect;
+pub use octree::{OctTree, OctTreeElement};
+pub use point::Point;
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::octree::octree::build_test_tree;
+
+    #[test]
+    fn insert_once_works() {
+        let mut tree = OctTree::default();
+        tree.insert(OctTreeElement::new(0, AABB::new(0, 0, 0, 1, 1, 1)))
+            .expect("insert should work");
+        assert_eq!(tree.count_element_references(), 1);
+
+        let inserted_ids = tree.collect_ids();
+        assert_eq!(inserted_ids.len(), 1);
+        assert!(inserted_ids.contains(&0));
+    }
+
+    #[test]
+    fn insert_twice_works() {
+        let mut tree = OctTree::default();
+        for id in 0..2i32 {
+            tree.insert(OctTreeElement::new(
+                id,
+                AABB::new(-id, -id, -id, id + 1, id + 1, id + 1),
+            ))
+            .expect("insert should work");
+        }
+        assert_eq!(tree.count_element_references(), 2);
+
+        let inserted_ids = tree.collect_ids();
+        assert_eq!(inserted_ids.len(), 2);
+        assert!(inserted_ids.contains(&0));
+        assert!(inserted_ids.contains(&1));
+    }
+
+    #[test]
+    fn intersect_aabb_works() {
+        let tree = build_test_tree();
+
+        let octant = AABB::new(-17, -17, -17, 0, 0, 0);
+        let results = tree.intersect_aabb(&octant);
+        assert_eq!(results.len(), 2);
+        assert!(results.contains(&1000));
+        assert!(!results.contains(&1001));
+        assert!(results.contains(&5000));
+    }
+
+    #[test]
+    fn intersect_generic_works() {
+        let tree = build_test_tree();
+
+        let octant = AABB::new(-17, -17, -17, 0, 0, 0);
+        let results = tree.intersect_generic(&octant);
+        assert_eq!(results.len(), 2);
+        assert!(results.contains(&1000));
+        assert!(!results.contains(&1001));
+        assert!(results.contains(&5000));
+    }
+
+    mod ray_box {
+        use super::*;
+        use crate::intersections::IntersectsWith;
+
+        struct Ray3 {
+            origin: [f32; 3],
+            inv_dir: [f32; 3],
+        }
+
+        impl Ray3 {
+            fn new(origin: [f32; 3], dir: [f32; 3]) -> Ray3 {
+                Ray3 {
+                    origin,
+                    inv_dir: [1.0 / dir[0], 1.0 / dir[1], 1.0 / dir[2]],
+                }
+            }
+        }
+
+        impl IntersectsWith<AABB> for Ray3 {
+            fn intersects_with(&self, other: &AABB) -> bool {
+                let mut tmin = f32::NEG_INFINITY;
+                let mut tmax = f32::INFINITY;
+
+                let bounds = [
+                    (other.min.x as f32, other.max.x as f32),
+                    (other.min.y as f32, other.max.y as f32),
+                    (other.min.z as f32, other.max.z as f32),
+                ];
+
+                for axis in 0..3 {
+                    let t1 = (bounds[axis].0 - self.origin[axis]) * self.inv_dir[axis];
+                    let t2 = (bounds[axis].1 - self.origin[axis]) * self.inv_dir[axis];
+                    let (t1, t2) = if t1 < t2 { (t1, t2) } else { (t2, t1) };
+                    tmin = tmin.max(t1);
+                    tmax = tmax.min(t2);
+                    if tmin > tmax {
+                        return false;
+                    }
+                }
+
+                tmax >= 0.0
+            }
+        }
+
+        #[test]
+        fn ray_box_intersection_works() {
+            let r#box = AABB::new(-5, -5, -5, 5, 5, 5);
+            let ray_inside = Ray3::new([0., 0., 0.], [0.1, 0.1, 1.]);
+            let ray_outside = Ray3::new([20., 0., 0.], [1., 0.1, 0.1]);
+            assert!(ray_inside.intersects_with(&r#box));
+            assert!(!ray_outside.intersects_with(&r#box));
+        }
+
+        #[test]
+        fn tree_ray_does_intersect() {
+            let tree = build_test_tree();
+            let ray = Ray3::new([1., 8., -10.], [1., 0.1, 1.]);
+            let results = tree.intersect_generic(&ray);
+            assert_eq!(results.len(), 1);
+            assert!(results.contains(&4000));
+        }
+    }
+}

--- a/src/octree/aabb.rs
+++ b/src/octree/aabb.rs
@@ -1,0 +1,152 @@
+use crate::intersections::IntersectsWith;
+use crate::octree::Point;
+use std::ops::{Add, RangeInclusive};
+
+/// An axis-aligned bounding box in 3D defined by its minimum and maximum corners.
+#[derive(Debug, PartialEq, Eq, Default, Copy, Clone)]
+pub struct AABB {
+    /// Minimum (left, top, front) corner.
+    pub min: Point,
+    /// Maximum (right, bottom, back) corner.
+    pub max: Point,
+}
+
+impl AABB {
+    /// Constructs a new [`AABB`] from the coordinates of its edges.
+    #[inline]
+    pub fn new(x1: i32, y1: i32, z1: i32, x2: i32, y2: i32, z2: i32) -> Self {
+        Self {
+            min: Point::new(x1, y1, z1),
+            max: Point::new(x2, y2, z2),
+        }
+    }
+
+    #[inline]
+    pub fn from_ranges(
+        x: RangeInclusive<i32>,
+        y: RangeInclusive<i32>,
+        z: RangeInclusive<i32>,
+    ) -> Self {
+        Self {
+            min: Point::new(*x.start(), *y.start(), *z.start()),
+            max: Point::new(*x.end(), *y.end(), *z.end()),
+        }
+    }
+}
+
+impl IntersectsWith<AABB> for AABB {
+    /// Tests whether this [`AABB`] intersects with another one.
+    #[inline]
+    fn intersects_with(&self, other: &AABB) -> bool {
+        let x1_max = self.min.x.max(other.min.x);
+        let x2_min = self.max.x.min(other.max.x);
+        let y1_max = self.min.y.max(other.min.y);
+        let y2_min = self.max.y.min(other.max.y);
+        let z1_max = self.min.z.max(other.min.z);
+        let z2_min = self.max.z.min(other.max.z);
+
+        let intersects = (x1_max < x2_min) & (y1_max < y2_min) & (z1_max < z2_min);
+
+        let d_a = x1_max <= x2_min;
+        let d_b = y1_max <= y2_min;
+        let d_c = z1_max <= z2_min;
+
+        let degenerate_x = (other.min.x == other.max.x) | (self.min.x == self.max.x);
+        let degenerate_y = (other.min.y == other.max.y) | (self.min.y == self.max.y);
+        let degenerate_z = (other.min.z == other.max.z) | (self.min.z == self.max.z);
+        let is_degenerate = degenerate_x | degenerate_y | degenerate_z;
+        let d_intersects = is_degenerate & d_a & d_b & d_c;
+
+        intersects | d_intersects
+    }
+}
+
+impl Add for AABB {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        let min_x = self.min.x.min(rhs.min.x);
+        let min_y = self.min.y.min(rhs.min.y);
+        let min_z = self.min.z.min(rhs.min.z);
+        let max_x = self.max.x.max(rhs.max.x);
+        let max_y = self.max.y.max(rhs.max.y);
+        let max_z = self.max.z.max(rhs.max.z);
+        AABB::new(min_x, min_y, min_z, max_x, max_y, max_z)
+    }
+}
+
+impl From<[i32; 6]> for AABB {
+    #[inline]
+    fn from(rect: [i32; 6]) -> Self {
+        Self::from(&rect)
+    }
+}
+
+impl From<&[i32; 6]> for AABB {
+    #[inline]
+    fn from(rect: &[i32; 6]) -> Self {
+        Self::new(rect[0], rect[1], rect[2], rect[3], rect[4], rect[5])
+    }
+}
+
+impl From<AABB> for [i32; 6] {
+    fn from(val: AABB) -> Self {
+        [
+            val.min.x, val.min.y, val.min.z, val.max.x, val.max.y, val.max.z,
+        ]
+    }
+}
+
+impl AsRef<[i32; 6]> for AABB {
+    fn as_ref(&self) -> &[i32; 6] {
+        let ptr = self as *const _ as *const [i32; 6];
+        unsafe { ptr.as_ref() }.unwrap()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn aabb_is_24_bytes() {
+        assert_eq!(std::mem::size_of::<AABB>(), 24);
+    }
+
+    #[test]
+    fn from_works() {
+        let aabb = AABB::from([1, 2, 3, 4, 5, 6]);
+        assert_eq!(aabb.min.x, 1);
+        assert_eq!(aabb.min.y, 2);
+        assert_eq!(aabb.min.z, 3);
+        assert_eq!(aabb.max.x, 4);
+        assert_eq!(aabb.max.y, 5);
+        assert_eq!(aabb.max.z, 6);
+    }
+
+    #[test]
+    fn from_ref_works() {
+        let aabb = AABB::from(&[1, 2, 3, 4, 5, 6]);
+        assert_eq!(aabb.min.x, 1);
+        assert_eq!(aabb.min.y, 2);
+        assert_eq!(aabb.min.z, 3);
+        assert_eq!(aabb.max.x, 4);
+        assert_eq!(aabb.max.y, 5);
+        assert_eq!(aabb.max.z, 6);
+    }
+
+    #[test]
+    fn as_ref_works() {
+        let aabb = AABB::new(1, 2, 3, 4, 5, 6);
+        let array: &[i32; 6] = aabb.as_ref();
+        for i in 1..=6 {
+            assert_eq!(array[i as usize - 1], i);
+        }
+    }
+
+    #[test]
+    fn intersects_with_self_works() {
+        let a = AABB::new(0, 0, 0, 1, 1, 1);
+        assert!(a.intersects_with(&a));
+    }
+}

--- a/src/octree/centered_aabb.rs
+++ b/src/octree/centered_aabb.rs
@@ -1,0 +1,218 @@
+use crate::intersections::IntersectsWith;
+use crate::octree::octants::Octants;
+use crate::octree::AABB;
+use std::ops::RangeInclusive;
+
+/// A centered axis-aligned bounding box in 3D.
+#[derive(Debug, Default, Copy, Clone)]
+#[repr(C, align(8))]
+pub struct CenteredAABB {
+    pub center_x: i32,
+    pub center_y: i32,
+    pub center_z: i32,
+    pub half_width: i32,
+    pub half_height: i32,
+    pub half_depth: i32,
+}
+
+impl CenteredAABB {
+    #[inline]
+    pub fn from_ltfwhd(
+        left: i32,
+        top: i32,
+        front: i32,
+        width: i32,
+        height: i32,
+        depth: i32,
+    ) -> Self {
+        let hx = width >> 1;
+        let hy = height >> 1;
+        let hz = depth >> 1;
+        let mx = left + hx;
+        let my = top + hy;
+        let mz = front + hz;
+        Self {
+            center_x: mx,
+            center_y: my,
+            center_z: mz,
+            half_width: hx,
+            half_height: hy,
+            half_depth: hz,
+        }
+    }
+
+    #[inline]
+    pub fn explore_octants_aabb(&self, other: &AABB) -> Octants {
+        let explore_left = other.min.x <= self.center_x;
+        let explore_right = other.max.x > self.center_x;
+        let explore_top = other.min.y <= self.center_y;
+        let explore_bottom = other.max.y > self.center_y;
+        let explore_front = other.min.z <= self.center_z;
+        let explore_back = other.max.z > self.center_z;
+        Octants::from_tests(
+            explore_left,
+            explore_top,
+            explore_right,
+            explore_bottom,
+            explore_front,
+            explore_back,
+        )
+    }
+
+    #[inline]
+    pub fn explore_octants_generic<T>(&self, other: &T) -> Octants
+    where
+        T: IntersectsWith<AABB>,
+    {
+        let l = self.left_half();
+        let r = self.right_half();
+        let t = self.top_half();
+        let b = self.bottom_half();
+        let f = self.front_half();
+        let ba = self.back_half();
+
+        let ltf = AABB::from_ranges(l.clone(), t.clone(), f.clone());
+        let rtf = AABB::from_ranges(r.clone(), t.clone(), f.clone());
+        let lbf = AABB::from_ranges(l.clone(), b.clone(), f.clone());
+        let rbf = AABB::from_ranges(r.clone(), b.clone(), f.clone());
+        let ltb = AABB::from_ranges(l.clone(), t.clone(), ba.clone());
+        let rtb = AABB::from_ranges(r.clone(), t.clone(), ba.clone());
+        let lbb = AABB::from_ranges(l.clone(), b.clone(), ba.clone());
+        let rbb = AABB::from_ranges(r, b, ba);
+
+        Octants::from_intersections(
+            other.intersects_with(&ltf),
+            other.intersects_with(&rtf),
+            other.intersects_with(&lbf),
+            other.intersects_with(&rbf),
+            other.intersects_with(&ltb),
+            other.intersects_with(&rtb),
+            other.intersects_with(&lbb),
+            other.intersects_with(&rbb),
+        )
+    }
+
+    #[inline]
+    pub fn get_aabb(&self) -> AABB {
+        AABB::new(
+            self.left(),
+            self.top(),
+            self.front(),
+            self.right(),
+            self.bottom(),
+            self.back(),
+        )
+    }
+
+    #[inline]
+    pub fn split_octants(&self) -> [CenteredAABB; 9] {
+        let hx = self.half_width >> 1;
+        let hy = self.half_height >> 1;
+        let hz = self.half_depth >> 1;
+
+        let cx_l = self.center_x - hx;
+        let cx_r = self.center_x + hx;
+        let cy_t = self.center_y - hy;
+        let cy_b = self.center_y + hy;
+        let cz_f = self.center_z - hz;
+        let cz_b = self.center_z + hz;
+
+        let child = |cx, cy, cz| CenteredAABB {
+            center_x: cx,
+            center_y: cy,
+            center_z: cz,
+            half_width: hx,
+            half_height: hy,
+            half_depth: hz,
+        };
+
+        [
+            *self,
+            child(cx_l, cy_t, cz_f),
+            child(cx_r, cy_t, cz_f),
+            child(cx_l, cy_b, cz_f),
+            child(cx_r, cy_b, cz_f),
+            child(cx_l, cy_t, cz_b),
+            child(cx_r, cy_t, cz_b),
+            child(cx_l, cy_b, cz_b),
+            child(cx_r, cy_b, cz_b),
+        ]
+    }
+
+    #[inline]
+    fn left_half(&self) -> RangeInclusive<i32> {
+        self.left()..=self.center_x
+    }
+
+    #[inline]
+    fn right_half(&self) -> RangeInclusive<i32> {
+        self.center_x..=self.right()
+    }
+
+    #[inline]
+    fn top_half(&self) -> RangeInclusive<i32> {
+        self.top()..=self.center_y
+    }
+
+    #[inline]
+    fn bottom_half(&self) -> RangeInclusive<i32> {
+        self.center_y..=self.bottom()
+    }
+
+    #[inline]
+    fn front_half(&self) -> RangeInclusive<i32> {
+        self.front()..=self.center_z
+    }
+
+    #[inline]
+    fn back_half(&self) -> RangeInclusive<i32> {
+        self.center_z..=self.back()
+    }
+
+    #[inline]
+    pub fn left(&self) -> i32 {
+        self.center_x - self.half_width
+    }
+
+    #[inline]
+    pub fn right(&self) -> i32 {
+        self.center_x + self.half_width
+    }
+
+    #[inline]
+    pub fn top(&self) -> i32 {
+        self.center_y - self.half_height
+    }
+
+    #[inline]
+    pub fn bottom(&self) -> i32 {
+        self.center_y + self.half_height
+    }
+
+    #[inline]
+    pub fn front(&self) -> i32 {
+        self.center_z - self.half_depth
+    }
+
+    #[inline]
+    pub fn back(&self) -> i32 {
+        self.center_z + self.half_depth
+    }
+}
+
+impl From<CenteredAABB> for AABB {
+    #[inline]
+    fn from(val: CenteredAABB) -> Self {
+        val.get_aabb()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn centered_aabb_is_24_bytes() {
+        assert_eq!(std::mem::size_of::<CenteredAABB>(), 24);
+    }
+}

--- a/src/octree/error.rs
+++ b/src/octree/error.rs
@@ -1,0 +1,17 @@
+use std::{error, fmt};
+
+#[derive(Debug)]
+pub enum InsertError {
+    /// The element that was about to be inserted was outside of the bounds of the OctTree.
+    OutOfBounds,
+}
+
+impl fmt::Display for InsertError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            Self::OutOfBounds => write!(f, "the element was outside of the tree bounds"),
+        }
+    }
+}
+
+impl error::Error for InsertError {}

--- a/src/octree/free_list.rs
+++ b/src/octree/free_list.rs
@@ -1,0 +1,351 @@
+use std::mem::ManuallyDrop;
+
+pub(crate) type IndexType = u32;
+pub(crate) const SENTINEL: IndexType = IndexType::MAX;
+
+/// Provides an indexed free list with constant-time removals from anywhere
+/// in the list without invalidating indices. T must be trivially constructible
+/// and destructible.
+pub struct FreeList<T>
+where
+    T: Default,
+{
+    /// The number of live elements in the list.
+    #[cfg(debug_assertions)]
+    length: usize,
+    /// The actual data.
+    data: Vec<FreeElement<T>>,
+    /// The index of the the most recently freed element, or `SENTINEL` if no
+    /// element is free.
+    first_free: IndexType,
+}
+
+union FreeElement<T> {
+    /// This field contains the data as long as the element was not removed.
+    element: ManuallyDrop<T>,
+    /// If the element was "removed", this index is pointing to the next index
+    /// of an element that is also freed, or `SENTINEL` if no other element is free.
+    next: IndexType,
+}
+
+impl<T> Default for FreeList<T>
+where
+    T: Default,
+{
+    fn default() -> Self {
+        Self {
+            data: Vec::default(),
+            first_free: SENTINEL,
+            #[cfg(debug_assertions)]
+            length: 0,
+        }
+    }
+}
+
+impl<T> FreeList<T>
+where
+    T: Default,
+{
+    /// Inserts an element to the free list and returns an index to it.
+    pub fn insert(&mut self, element: T) -> IndexType {
+        #[cfg(debug_assertions)]
+        {
+            self.length += 1;
+        }
+
+        if self.first_free != SENTINEL {
+            let index = self.first_free;
+
+            // Set the "first free" pointer to the next free index.
+            self.first_free = unsafe { self.data[self.first_free as usize].next };
+
+            // Place the element into the previously free location.
+            self.data[index as usize].element = ManuallyDrop::new(element);
+            index
+        } else {
+            let fe = FreeElement {
+                element: ManuallyDrop::new(element),
+            };
+            self.data.push(fe);
+            (self.data.len() - 1) as IndexType
+        }
+    }
+
+    /// Removes the nth element from the free list.
+    pub fn erase(&mut self, n: IndexType) {
+        self.first_free = SENTINEL;
+        if self.data.is_empty() {
+            return;
+        }
+        debug_assert!(!self.debug_is_in_free_list(n));
+
+        #[cfg(debug_assertions)]
+        debug_assert!(self.length > 0);
+
+        unsafe { ManuallyDrop::drop(&mut self.data[n as usize].element) };
+        self.data[n as usize].next = self.first_free;
+        self.first_free = n;
+
+        #[cfg(debug_assertions)]
+        {
+            self.length -= 1;
+        }
+    }
+
+    /// Removes all elements from the free list.
+    pub fn clear(&mut self) {
+        if self.data.is_empty() {
+            assert_eq!(self.first_free, SENTINEL);
+            return;
+        }
+
+        // Collect all free indexes and sort them such that they
+        // are in ascending order.
+        let mut free_indexes = Vec::new();
+        let mut token = self.first_free;
+        while token != SENTINEL {
+            free_indexes.push(token);
+            token = unsafe { self.data[token as usize].next };
+        }
+        free_indexes.sort();
+
+        // As long as there are free indexes, pop elements from the
+        // vector and ignore them if they correspond to a free index.
+        if !free_indexes.is_empty() {
+            for (i, entry) in self.data.iter_mut().enumerate() {
+                if free_indexes.is_empty() || *free_indexes.last().unwrap() != (i as IndexType) {
+                    // This is not a pointer entry, drop required.
+                    unsafe { ManuallyDrop::drop(&mut entry.element) };
+                } else {
+                    // The entry only contains a index to another free spot; nothing to drop.
+                    let _ = free_indexes.pop();
+                }
+            }
+        }
+
+        // At this point there are no free indexes anymore, so the
+        // list can be trivially cleared.
+        self.data.clear();
+        self.first_free = SENTINEL;
+
+        #[cfg(debug_assertions)]
+        {
+            self.length = 0;
+        }
+    }
+
+    /// Gets a reference to the value at the specified index.
+    ///
+    /// # Safety
+    ///
+    /// If the element at the specified index was erased, the union now acts
+    ///  as a pointer to the next free element. Accessing the same index again after that.
+    ///  is undefined behavior.
+    #[inline]
+    pub unsafe fn at(&self, index: IndexType) -> &T {
+        debug_assert_ne!(index, SENTINEL);
+        debug_assert!(!self.debug_is_in_free_list(index));
+        &self.data[index as usize].element
+    }
+
+    /// Gets a mutable reference to the value at the specified index.
+    ///
+    /// # Safety
+    ///
+    /// If the element at the specified index was erased, the union now acts
+    /// as a pointer to the next free element. Accessing the same index again after that.
+    /// is undefined behavior.
+    #[inline]
+    pub unsafe fn at_mut(&mut self, index: IndexType) -> &mut T {
+        debug_assert_ne!(index, SENTINEL);
+        debug_assert!(!self.debug_is_in_free_list(index));
+        &mut self.data[index as usize].element
+    }
+
+    /// Gets the current capacity of the list.
+    #[allow(dead_code)]
+    pub fn capacity(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Gets the number of elements in the list.
+    #[allow(dead_code)]
+    pub fn debug_len(&self) -> usize {
+        #[cfg(debug_assertions)]
+        return self.length;
+        #[cfg(not(debug_assertions))]
+        unimplemented!()
+    }
+
+    #[allow(dead_code, unused_variables)]
+    fn debug_is_in_free_list(&self, n: IndexType) -> bool {
+        #[cfg(any(debug_assertions, test))]
+        {
+            assert_ne!(n, SENTINEL);
+            let mut token = self.first_free;
+            while token != SENTINEL {
+                if n == token {
+                    return true;
+                }
+                token = unsafe { self.data[token as usize].next };
+            }
+            false
+        }
+        #[cfg(not(any(debug_assertions, test)))]
+        unimplemented!()
+    }
+}
+
+impl<T> Drop for FreeList<T>
+where
+    T: Default,
+{
+    fn drop(&mut self) {
+        self.clear();
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[derive(Default, Debug, PartialEq, PartialOrd)]
+    struct Complex(f64, f64);
+
+    impl Drop for Complex {
+        fn drop(&mut self) {
+            self.0 = 42.;
+            self.1 = 1337.0;
+        }
+    }
+
+    #[test]
+    fn after_construction_has_no_first_free() {
+        let list = FreeList::<Complex>::default();
+        assert_eq!(list.first_free, SENTINEL);
+        assert_eq!(list.capacity(), 0);
+    }
+
+    #[test]
+    fn after_insertion_has_no_first_free() {
+        let mut list = FreeList::<Complex>::default();
+        assert_eq!(list.insert(Complex::default()), 0);
+        assert_eq!(list.first_free, SENTINEL);
+        assert_eq!(list.capacity(), 1);
+    }
+
+    #[test]
+    fn after_deletion_has_a_first_free() {
+        let mut list = FreeList::<Complex>::default();
+        list.insert(Complex::default());
+        list.erase(0);
+        assert_eq!(list.first_free, 0);
+        assert_eq!(list.capacity(), 1);
+    }
+
+    #[test]
+    fn insert_after_delete_has_no_free() {
+        let mut list = FreeList::<Complex>::default();
+        list.insert(Complex::default());
+        list.erase(0);
+        list.insert(Complex::default());
+        assert_eq!(list.first_free, SENTINEL);
+        assert_eq!(list.capacity(), 1);
+    }
+
+    #[test]
+    fn first_free_points_to_last_freed_index() {
+        let mut list = FreeList::<Complex>::default();
+        insert_some(&mut list, 2);
+        list.erase(0);
+        list.erase(1);
+        assert_eq!(list.first_free, 1);
+        assert_eq!(list.capacity(), 2);
+    }
+
+    #[test]
+    fn erase_in_ascending_order() {
+        let mut list = FreeList::<Complex>::default();
+        insert_some(&mut list, 4);
+        list.erase(0);
+        list.erase(1);
+        list.erase(2);
+        list.erase(3);
+        assert_eq!(list.first_free, 3);
+        assert_eq!(list.capacity(), 4);
+    }
+
+    #[test]
+    fn erase_in_descending_order() {
+        let mut list = FreeList::<Complex>::default();
+        insert_some(&mut list, 4);
+        list.erase(3);
+        list.erase(2);
+        list.erase(1);
+        list.erase(0);
+        assert_eq!(list.first_free, 0);
+        assert_eq!(list.capacity(), 4);
+    }
+
+    #[test]
+    fn erase_in_mixed_order() {
+        let mut list = FreeList::<Complex>::default();
+        insert_some(&mut list, 4);
+        list.erase(0);
+        list.erase(3);
+        list.erase(1);
+        list.erase(2);
+        assert_eq!(list.first_free, 2);
+        assert_eq!(list.capacity(), 4);
+    }
+
+    #[test]
+    fn clear_works() {
+        let mut list = FreeList::<Complex>::default();
+        insert_some(&mut list, 4);
+        list.erase(1);
+        list.clear();
+        list.clear();
+        assert_eq!(list.first_free, SENTINEL);
+        assert_eq!(list.capacity(), 0);
+    }
+
+    #[test]
+    fn is_in_free_list_works() {
+        let mut list = FreeList::<Complex>::default();
+        insert_some(&mut list, 2);
+        list.erase(0);
+        assert!(list.debug_is_in_free_list(0));
+        assert!(!list.debug_is_in_free_list(1));
+    }
+
+    #[test]
+    fn at_works() {
+        let mut list = FreeList::<Complex>::default();
+        list.insert(Complex(1., 2.));
+        list.insert(Complex::default());
+        let element = unsafe { list.at(0) };
+        assert_eq!(*element, Complex(1., 2.));
+    }
+
+    #[test]
+    fn at_mut_works() {
+        let mut list = FreeList::<Complex>::default();
+        list.insert(Complex(1., 2.));
+        list.insert(Complex::default());
+
+        // Mutably access the element and exchange it.
+        let element = unsafe { list.at_mut(0) };
+        *element = Complex::default();
+
+        // Get a new reference and verify.
+        let element = unsafe { list.at(0) };
+        assert_eq!(*element, Complex(0., 0.));
+    }
+
+    fn insert_some(list: &mut FreeList<Complex>, n: usize) {
+        for _ in 0..n {
+            list.insert(Complex::default());
+        }
+    }
+}

--- a/src/octree/node.rs
+++ b/src/octree/node.rs
@@ -1,0 +1,135 @@
+use crate::octree::free_list;
+use std::fmt::{Debug, Formatter};
+
+pub type NodeElementCountType = u32;
+
+/// This value encodes that a node is a branch, i.e., not a leaf.
+const NODE_IS_BRANCH: u32 = NodeElementCountType::MAX;
+const CHILD_COUNT: free_list::IndexType = 9;
+
+/// Represents a node in the octree.
+#[derive(Copy, Clone)]
+pub struct Node {
+    /// Contains
+    /// - the index of the first child if this node is a branch or
+    /// - the index of the first element if this node is a leaf or
+    /// - `free_list::SENTINEL` if neither of which exists.
+    ///
+    /// If this node is the first child node and pointed to by
+    /// the free node pointer, all subsequent nodes of the same parent (i.e., the next three nodes).
+    pub first_child_or_element: free_list::IndexType,
+    /// Stores the number of elements in the leaf or `NODE_INDEX_IS_BRANCH if it this node is
+    /// a branch (i.e., not a leaf).
+    pub element_count: NodeElementCountType,
+}
+
+impl Debug for Node {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match (self.element_count, self.first_child_or_element) {
+            (NODE_IS_BRANCH, free_list::SENTINEL) => {
+                write!(f, "Branch, no child nodes")
+            }
+            (NODE_IS_BRANCH, child_index) => write!(
+                f,
+                "Branch, child nodes at {}+{}..={}",
+                child_index,
+                child_index + 1,
+                child_index + CHILD_COUNT - 1
+            ),
+            (0, free_list::SENTINEL) => write!(f, "Leaf, no elements"),
+            (count, free_list::SENTINEL) => {
+                panic!("Got {} child elements but no data pointer", count)
+            }
+            (count, element_index) => write!(
+                f,
+                "Leaf, elements {}..={}",
+                element_index,
+                element_index + count
+            ),
+        }
+    }
+}
+
+impl Default for Node {
+    #[inline]
+    fn default() -> Self {
+        let node = Self {
+            // By setting the first element index to the sentinel value,
+            // we encode that this node has no data.
+            first_child_or_element: free_list::SENTINEL,
+            // By setting the element count to zero, this is now a leaf with 0 elements.
+            element_count: 0,
+        };
+        // For brevity:
+        debug_assert!(node.is_leaf() && node.is_empty());
+        node
+    }
+}
+
+impl Node {
+    /// Returns whether the node stores elements.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.element_count == 0
+    }
+
+    /// Determines whether this node is a branch.
+    ///
+    /// Leaf nodes do not contain data, and their [`first_child_or_element`]
+    /// field points to the index of the child node.
+    #[inline]
+    pub fn is_branch(&self) -> bool {
+        self.element_count == NODE_IS_BRANCH
+    }
+
+    /// Determines whether this node is a leaf (i.e., not a branch).
+    ///
+    /// Leaf nodes may contain data, and their [`first_child_or_element`]
+    /// field points to the index of the first element.
+    #[inline]
+    pub fn is_leaf(&self) -> bool {
+        // If we have a nonzero element count, the [`first_child_or_element`] must be a valid index.
+        // If we have a zero element count, the [`first_child_or_element`] must be the sentinel value.
+        debug_assert!(self.element_count > 0 || self.first_child_or_element == free_list::SENTINEL);
+
+        !self.is_branch()
+    }
+
+    /// If the node is branch, gets the index of the first child node.
+    #[inline]
+    pub fn get_first_child_node_index(&self) -> free_list::IndexType {
+        debug_assert!(self.is_branch());
+        self.first_child_or_element
+    }
+
+    /// If the node is leaf, gets the index of the element node.
+    #[inline]
+    pub fn get_first_element_node_index(&self) -> free_list::IndexType {
+        debug_assert!(self.is_leaf());
+        self.first_child_or_element
+    }
+
+    /// Make this node an empty leaf.
+    #[inline]
+    pub fn make_empty_leaf(&mut self) {
+        self.first_child_or_element = free_list::SENTINEL;
+        self.element_count = 0;
+    }
+
+    /// Make this node a branch.
+    #[inline]
+    pub fn make_branch(&mut self, first_child: free_list::IndexType) {
+        self.first_child_or_element = first_child;
+        self.element_count = NODE_IS_BRANCH;
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn oct_node_is_eight_bytes() {
+        assert_eq!(std::mem::size_of::<Node>(), 8);
+    }
+}

--- a/src/octree/node_data.rs
+++ b/src/octree/node_data.rs
@@ -1,0 +1,96 @@
+use crate::octree::centered_aabb::CenteredAABB;
+use crate::octree::oct_rect::OctRect;
+use crate::octree::AABB;
+
+pub type NodeIndexType = u32;
+
+#[derive(Debug)]
+#[repr(C, align(8))]
+pub struct NodeData {
+    /// The centered AABB of the node: center x, center y, center z and half-sizes.
+    pub crect: CenteredAABB,
+    /// The index of the `Node` described by this `NodeData` instance.
+    pub(crate) index: NodeIndexType,
+    /// The depth of the node.
+    pub depth: u8,
+    flags: NodeFlags,
+}
+
+const CAN_SPLIT_FLAG: u8 = 1;
+
+#[derive(Debug)]
+#[repr(C, align(1))]
+struct NodeFlags {
+    flags: u8,
+}
+
+impl NodeFlags {
+    pub fn new(can_split: bool) -> NodeFlags {
+        let mut flags = 0u8;
+        if can_split {
+            flags |= CAN_SPLIT_FLAG;
+        }
+        Self { flags }
+    }
+
+    pub fn can_split(&self) -> bool {
+        (self.flags & CAN_SPLIT_FLAG) > 0
+    }
+}
+
+impl NodeData {
+    #[inline]
+    pub(crate) fn new(crect: CenteredAABB, index: u32, depth: u8, can_split: bool) -> Self {
+        Self::new_from_centered_aabb(index, depth, crect, can_split)
+    }
+
+    #[inline]
+    pub(crate) fn new_from_root(root_rect: &OctRect, can_split: bool) -> Self {
+        Self::new_from_centered_aabb(0, 0, root_rect.into(), can_split)
+    }
+
+    #[inline]
+    fn new_from_centered_aabb(index: u32, depth: u8, crect: CenteredAABB, can_split: bool) -> Self {
+        Self {
+            index,
+            crect,
+            depth,
+            flags: NodeFlags::new(can_split),
+        }
+    }
+
+    /// Determines if a node is at least `smallest_size` in any dimension,
+    /// guaranteeing that after subdivision, each cell would be of a usable size.
+    /// Additionally, ensures that the node has not reached its maximum depth.
+    #[inline]
+    pub fn can_split_further(&self, smallest_size: u32, max_depth: u8) -> bool {
+        let splittable = self.flags.can_split();
+        let split_allowed = self.can_subdivide(smallest_size);
+        let can_go_deeper = self.depth < max_depth;
+        split_allowed & can_go_deeper & splittable
+    }
+
+    #[inline]
+    fn can_subdivide(&self, smallest_size: u32) -> bool {
+        let can_split_width = self.crect.half_width >= smallest_size as _;
+        let can_split_height = self.crect.half_height >= smallest_size as _;
+        let can_split_depth = self.crect.half_depth >= smallest_size as _;
+        can_split_width | can_split_height | can_split_depth
+    }
+}
+
+impl From<NodeData> for AABB {
+    fn from(val: NodeData) -> Self {
+        val.crect.into()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn node_data_size() {
+        assert_eq!(std::mem::size_of::<NodeData>(), 32);
+    }
+}

--- a/src/octree/node_info.rs
+++ b/src/octree/node_info.rs
@@ -1,0 +1,25 @@
+use crate::octree::node::NodeElementCountType;
+use crate::octree::node_data::NodeData;
+use crate::octree::AABB;
+
+#[derive(Debug)]
+pub struct NodeInfo {
+    pub(crate) nd: NodeData,
+    pub element_count: u32,
+}
+
+impl NodeInfo {
+    #[inline]
+    pub(crate) fn from(nd: NodeData, element_count: NodeElementCountType) -> Self {
+        Self { nd, element_count }
+    }
+
+    pub fn depth(&self) -> u8 {
+        self.nd.depth
+    }
+
+    #[inline]
+    pub fn get_aabb(&self) -> AABB {
+        self.nd.crect.get_aabb()
+    }
+}

--- a/src/octree/node_list.rs
+++ b/src/octree/node_list.rs
@@ -1,0 +1,41 @@
+use crate::octree::node_data::NodeData;
+use smallvec::SmallVec;
+use std::ops::Index;
+
+#[derive(Default)]
+pub struct NodeList {
+    elements: SmallVec<[NodeData; 64]>,
+}
+
+impl NodeList {
+    #[inline]
+    pub fn push_back(&mut self, nd: NodeData) {
+        self.elements.push(nd)
+    }
+
+    #[inline]
+    #[allow(dead_code)]
+    pub fn len(&self) -> usize {
+        self.elements.len()
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.elements.is_empty()
+    }
+
+    #[inline]
+    pub fn pop_back(&mut self) -> NodeData {
+        debug_assert!(!self.elements.is_empty());
+        self.elements.pop().unwrap()
+    }
+}
+
+impl Index<usize> for NodeList {
+    type Output = NodeData;
+
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.elements[index]
+    }
+}

--- a/src/octree/oct_rect.rs
+++ b/src/octree/oct_rect.rs
@@ -1,0 +1,80 @@
+use crate::octree::centered_aabb::CenteredAABB;
+use crate::octree::AABB;
+
+/// A rectangular prism describing the extents of the OctTree.
+/// Only the tree node stores its extents; bounding boxes for sub-nodes are computed on the fly.
+#[derive(Debug, Copy, Clone)]
+pub struct OctRect {
+    l: i32,
+    t: i32,
+    f: i32,
+    hx: i32,
+    hy: i32,
+    hz: i32,
+}
+
+impl OctRect {
+    pub fn new(left: i32, top: i32, front: i32, width: i32, height: i32, depth: i32) -> Self {
+        Self {
+            l: left,
+            t: top,
+            f: front,
+            hx: width,
+            hy: height,
+            hz: depth,
+        }
+    }
+
+    #[inline]
+    pub fn contains(&self, rect: &AABB) -> bool {
+        let mx = (rect.min.x + rect.max.x) >> 1;
+        let my = (rect.min.y + rect.max.y) >> 1;
+        let mz = (rect.min.z + rect.max.z) >> 1;
+
+        let r = self.l + self.hx;
+        let b = self.t + self.hy;
+        let ba = self.f + self.hz;
+        (mx >= self.l) & (mx <= r) & (my >= self.t) & (my <= b) & (mz >= self.f) & (mz <= ba)
+    }
+}
+
+impl Default for OctRect {
+    fn default() -> Self {
+        OctRect {
+            l: i32::MIN >> 1,
+            t: i32::MIN >> 1,
+            f: i32::MIN >> 1,
+            hx: i32::MAX,
+            hy: i32::MAX,
+            hz: i32::MAX,
+        }
+    }
+}
+
+impl From<OctRect> for AABB {
+    #[inline]
+    fn from(val: OctRect) -> Self {
+        AABB::new(
+            val.l,
+            val.t,
+            val.f,
+            val.l + val.hx,
+            val.t + val.hy,
+            val.f + val.hz,
+        )
+    }
+}
+
+impl From<OctRect> for CenteredAABB {
+    #[inline]
+    fn from(val: OctRect) -> Self {
+        CenteredAABB::from_ltfwhd(val.l, val.t, val.f, val.hx, val.hy, val.hz)
+    }
+}
+
+impl From<&OctRect> for CenteredAABB {
+    #[inline]
+    fn from(val: &OctRect) -> Self {
+        CenteredAABB::from_ltfwhd(val.l, val.t, val.f, val.hx, val.hy, val.hz)
+    }
+}

--- a/src/octree/octants.rs
+++ b/src/octree/octants.rs
@@ -1,0 +1,134 @@
+pub struct Octants {
+    /// Bit field encoding the octants.
+    /// - 0: Invalid
+    /// - 1: "this" node (covers multiple octants)
+    /// - 1<<1..=1<<8: the eight spatial octants
+    pub code: u16,
+}
+
+impl Octants {
+    #[inline]
+    #[allow(clippy::too_many_arguments)]
+    pub fn from_tests(
+        explore_left: bool,
+        explore_top: bool,
+        explore_right: bool,
+        explore_bottom: bool,
+        explore_front: bool,
+        explore_back: bool,
+    ) -> Self {
+        let covers_many = (explore_left & explore_right)
+            | (explore_top & explore_bottom)
+            | (explore_front & explore_back);
+
+        let ltf = ((explore_left & explore_top & explore_front) as u16) << 1;
+        let rtf = ((explore_right & explore_top & explore_front) as u16) << 2;
+        let lbf = ((explore_left & explore_bottom & explore_front) as u16) << 3;
+        let rbf = ((explore_right & explore_bottom & explore_front) as u16) << 4;
+        let ltb = ((explore_left & explore_top & explore_back) as u16) << 5;
+        let rtb = ((explore_right & explore_top & explore_back) as u16) << 6;
+        let lbb = ((explore_left & explore_bottom & explore_back) as u16) << 7;
+        let rbb = ((explore_right & explore_bottom & explore_back) as u16) << 8;
+
+        Octants {
+            code: (covers_many as u16) + ltf + rtf + lbf + rbf + ltb + rtb + lbb + rbb,
+        }
+    }
+
+    #[inline]
+    pub fn from_intersections(
+        ltf: bool,
+        rtf: bool,
+        lbf: bool,
+        rbf: bool,
+        ltb: bool,
+        rtb: bool,
+        lbb: bool,
+        rbb: bool,
+    ) -> Self {
+        let hits = ltf as u16
+            + rtf as u16
+            + lbf as u16
+            + rbf as u16
+            + ltb as u16
+            + rtb as u16
+            + lbb as u16
+            + rbb as u16;
+        let covers_many = hits > 1;
+        let this = covers_many as u16;
+
+        Octants {
+            code: this
+                + ((ltf as u16) << 1)
+                + ((rtf as u16) << 2)
+                + ((lbf as u16) << 3)
+                + ((rbf as u16) << 4)
+                + ((ltb as u16) << 5)
+                + ((rtb as u16) << 6)
+                + ((lbb as u16) << 7)
+                + ((rbb as u16) << 8),
+        }
+    }
+
+    #[inline]
+    pub fn self_only() -> Self {
+        Self { code: 1 }
+    }
+
+    #[inline]
+    pub fn all() -> Self {
+        Self {
+            code: 1 + 2 + 4 + 8 + 16 + 32 + 64 + 128 + 256,
+        }
+    }
+
+    #[inline]
+    pub fn this(&self) -> bool {
+        self.code & 1 == 1
+    }
+
+    #[inline]
+    pub fn at(&self, index: u32) -> bool {
+        let value = 1u16 << index;
+        self.code & value == value
+    }
+
+    /// Calculates the index into a nine-element array [this, LTF, RTF, LBF, RBF, LTB, RTB, LBB, RBB].
+    #[inline]
+    pub fn mutation_index(&self) -> u32 {
+        let octant_bits = self.code & !1;
+        if octant_bits.count_ones() != 1 {
+            return 0;
+        }
+        octant_bits.trailing_zeros()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn mutation_index_matches_octant() {
+        for i in 1..=8 {
+            let code = 1u16 << i;
+            let oct = Octants { code };
+            assert_eq!(oct.mutation_index(), i as u32);
+        }
+    }
+
+    #[test]
+    fn mutation_index_returns_zero_for_multi_hits() {
+        let oct = Octants {
+            code: (1 << 2) + (1 << 5),
+        };
+        assert_eq!(oct.mutation_index(), 0);
+    }
+
+    #[test]
+    fn self_bit_for_multi_axis_spans() {
+        let oct = Octants::from_tests(true, true, true, false, false, false);
+        assert!(oct.this());
+        assert_eq!(oct.mutation_index(), 0);
+    }
+}

--- a/src/octree/octree.rs
+++ b/src/octree/octree.rs
@@ -1,0 +1,726 @@
+use crate::intersections::IntersectsWith;
+use crate::octree::aabb::AABB;
+use crate::octree::centered_aabb::CenteredAABB;
+use crate::octree::error::InsertError;
+use crate::octree::free_list::{self, FreeList, IndexType};
+use crate::octree::node::Node;
+use crate::octree::node_data::{NodeData, NodeIndexType};
+use crate::octree::node_info::NodeInfo;
+use crate::octree::node_list::NodeList;
+use crate::octree::oct_rect::OctRect;
+use crate::octree::octants::Octants;
+use crate::octree::octree_element::OctTreeElementNode;
+pub use crate::octree::octree_element::{ElementIdType, OctTreeElement};
+use smallvec::SmallVec;
+
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+enum FindLeafHint {
+    Query,
+    Mutate,
+}
+
+/// A 3D Octree implementation following the same layout as the quadtree variant.
+pub struct OctTree<ElementId = u32>
+where
+    ElementId: ElementIdType,
+{
+    element_ids: FreeList<ElementId>,
+    element_rects: FreeList<AABB>,
+    element_nodes: FreeList<OctTreeElementNode>,
+    nodes: Vec<Node>,
+    root_rect: OctRect,
+    free_node: free_list::IndexType,
+    max_num_elements: u32,
+    smallest_cell_size: u32,
+    max_depth: u8,
+}
+
+impl<ElementId> OctTree<ElementId>
+where
+    ElementId: ElementIdType,
+{
+    pub fn new(
+        root_rect: OctRect,
+        max_depth: u8,
+        max_num_elements: u32,
+        smallest_cell_size: u32,
+    ) -> Self {
+        assert!(max_num_elements > 0);
+        assert!(smallest_cell_size > 0);
+        Self {
+            element_ids: FreeList::default(),
+            element_rects: FreeList::default(),
+            element_nodes: FreeList::default(),
+            nodes: vec![Node::default()],
+            root_rect,
+            free_node: free_list::SENTINEL,
+            max_depth,
+            max_num_elements,
+            smallest_cell_size,
+        }
+    }
+
+    pub fn insert(&mut self, element: OctTreeElement<ElementId>) -> Result<(), InsertError> {
+        let element_coords = &element.rect;
+        if !self.root_rect.contains(element_coords) {
+            return Err(InsertError::OutOfBounds);
+        }
+
+        let max_num_elements = self.max_num_elements;
+
+        let element_idx = self.element_ids.insert(element.id);
+        let element_rect_idx = self.element_rects.insert(element.rect);
+        debug_assert_eq!(element_idx, element_rect_idx);
+
+        let mut to_process: SmallVec<[NodeData; 128]> =
+            smallvec::smallvec![self.get_root_node_data()];
+
+        while let Some(node_data) = to_process.pop() {
+            let mut leaves = NodeList::default();
+            self.find_leaves_aabb_fn(
+                node_data,
+                element_coords,
+                FindLeafHint::Mutate,
+                |_rect, nd| {
+                    leaves.push_back(nd);
+                },
+            );
+
+            while !leaves.is_empty() {
+                let leaf = leaves.pop_back();
+                let (element_count, first_child_or_element) = {
+                    let node = &self.nodes[leaf.index as usize];
+                    debug_assert!(node.is_leaf());
+                    (node.element_count, node.first_child_or_element)
+                };
+
+                let can_split = leaf.can_split_further(self.smallest_cell_size, self.max_depth);
+                let node_is_full = element_count >= max_num_elements;
+
+                let must_store_element = !node_is_full || !can_split;
+                if must_store_element {
+                    let element_node_idx = self.element_nodes.insert(OctTreeElementNode {
+                        element_idx,
+                        next: first_child_or_element,
+                    });
+                    let node = &mut self.nodes[leaf.index as usize];
+                    node.first_child_or_element = element_node_idx;
+                    node.element_count += 1;
+                } else {
+                    self.distribute_elements_to_child_nodes(&leaf);
+                    to_process.push(leaf);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn distribute_elements_to_child_nodes(&mut self, parent: &NodeData) {
+        let first_child_index = self.ensure_child_nodes_exist();
+
+        let node = &mut self.nodes[parent.index as usize];
+        let mut element_node_index = node.get_first_element_node_index();
+        node.make_branch(first_child_index);
+
+        let mx = parent.crect.center_x;
+        let my = parent.crect.center_y;
+        let mz = parent.crect.center_z;
+
+        while element_node_index != free_list::SENTINEL {
+            let element_node = unsafe { *self.element_nodes.at(element_node_index) };
+            let element = unsafe { *self.element_rects.at(element_node.element_idx) };
+
+            self.assign_element_to_child_nodes(
+                mx,
+                my,
+                mz,
+                first_child_index,
+                element_node.element_idx,
+                &element,
+            );
+
+            self.element_nodes.erase(element_node_index);
+
+            element_node_index = element_node.next;
+        }
+    }
+
+    fn ensure_child_nodes_exist(&mut self) -> u32 {
+        if self.free_node != free_list::SENTINEL {
+            let node_index = self.free_node;
+            let next_free_node = self.nodes[node_index as usize].first_child_or_element;
+            self.nodes[node_index as usize] = Node::default();
+            self.free_node = next_free_node;
+            node_index
+        } else {
+            let node_index = self.nodes.len() as IndexType;
+            self.nodes.push(Node::default());
+            for _ in 0..8 {
+                self.nodes.push(Node::default());
+            }
+            node_index
+        }
+    }
+
+    fn assign_element_to_child_nodes(
+        &mut self,
+        mx: i32,
+        my: i32,
+        mz: i32,
+        first_child_index: free_list::IndexType,
+        element_index: free_list::IndexType,
+        element_rect: &AABB,
+    ) {
+        let insert_left = element_rect.min.x <= mx;
+        let insert_right = element_rect.max.x > mx;
+        let insert_top = element_rect.min.y <= my;
+        let insert_bottom = element_rect.max.y > my;
+        let insert_front = element_rect.min.z <= mz;
+        let insert_back = element_rect.max.z > mz;
+
+        let covers_many = (insert_top & insert_bottom)
+            | (insert_left & insert_right)
+            | (insert_front & insert_back);
+        if covers_many {
+            self.insert_element_in_child_node(first_child_index, element_index);
+            return;
+        }
+
+        let mut offset = 1;
+        if insert_right {
+            offset += 1;
+        }
+        if insert_bottom {
+            offset += 2;
+        }
+        if insert_back {
+            offset += 4;
+        }
+        self.insert_element_in_child_node(first_child_index + offset, element_index);
+    }
+
+    fn insert_element_in_child_node(&mut self, child_index: u32, element: free_list::IndexType) {
+        let node = &mut self.nodes[child_index as usize];
+        let element_node_index = self.element_nodes.insert(OctTreeElementNode {
+            element_idx: element,
+            next: node.first_child_or_element,
+        });
+        node.first_child_or_element = element_node_index;
+        node.element_count += 1;
+    }
+
+    pub fn remove(&mut self, element: &OctTreeElement<ElementId>) -> bool {
+        let element_coords = &element.rect;
+        let root = self.get_root_node_data();
+
+        let mut found_element_idx = free_list::SENTINEL;
+
+        let mut leaves = NodeList::default();
+        self.find_leaves_aabb_fn(root, element_coords, FindLeafHint::Mutate, |_rect, nd| {
+            leaves.push_back(nd);
+        });
+
+        while !leaves.is_empty() {
+            let leaf = leaves.pop_back();
+            let leaf_node_data = self.nodes[leaf.index as usize];
+
+            if leaf_node_data.element_count == 0 {
+                continue;
+            }
+
+            let mut element_found = false;
+
+            let mut element_node_idx = leaf_node_data.first_child_or_element;
+            let mut prev_element_node_idx = element_node_idx;
+            let mut new_first_child_or_element = element_node_idx;
+
+            while element_node_idx != free_list::SENTINEL {
+                let elem_node = *unsafe { self.element_nodes.at(element_node_idx) };
+                let elem_id = unsafe { self.element_ids.at(elem_node.element_idx) };
+
+                if *elem_id == element.id {
+                    debug_assert!(!element_found);
+                    element_found = true;
+
+                    if leaf_node_data.first_child_or_element == element_node_idx {
+                        new_first_child_or_element = elem_node.next;
+                    }
+
+                    if element_node_idx != prev_element_node_idx {
+                        unsafe { self.element_nodes.at_mut(prev_element_node_idx) }.next =
+                            elem_node.next;
+                    }
+
+                    self.element_nodes.erase(element_node_idx);
+                    debug_assert!(
+                        found_element_idx == free_list::SENTINEL
+                            || found_element_idx == elem_node.element_idx
+                    );
+                    found_element_idx = elem_node.element_idx;
+                }
+
+                prev_element_node_idx = element_node_idx;
+                element_node_idx = elem_node.next;
+
+                #[cfg(not(debug_assertions))]
+                if element_found {
+                    break;
+                }
+            }
+
+            let node = &mut self.nodes[leaf.index as usize];
+            node.first_child_or_element = new_first_child_or_element;
+
+            if element_found {
+                debug_assert!(node.element_count > 0);
+                node.element_count -= 1;
+            }
+        }
+
+        if found_element_idx != free_list::SENTINEL {
+            self.element_ids.erase(found_element_idx);
+            self.element_rects.erase(found_element_idx);
+            true
+        } else {
+            false
+        }
+    }
+
+    fn find_leaves_aabb_fn<F>(
+        &self,
+        root: NodeData,
+        rect: &AABB,
+        hint: FindLeafHint,
+        mut callback: F,
+    ) where
+        F: FnMut(&AABB, NodeData),
+    {
+        let mut to_process = NodeList::default();
+        to_process.push_back(root);
+
+        while !to_process.is_empty() {
+            let nd = to_process.pop_back();
+
+            if self.nodes[nd.index as usize].is_leaf() {
+                callback(rect, nd);
+                continue;
+            }
+
+            let fc = self.nodes[nd.index as usize].get_first_child_node_index();
+
+            let octants = nd.crect.explore_octants_aabb(rect);
+            Self::collect_relevant_octants(&mut to_process, &nd, fc, octants, hint)
+        }
+    }
+
+    fn find_leaves_generic_fn<T, F>(&self, root: NodeData, element: &T, mut callback: F)
+    where
+        T: IntersectsWith<AABB>,
+        F: FnMut(NodeData),
+    {
+        let mut to_process = NodeList::default();
+        to_process.push_back(root);
+
+        while !to_process.is_empty() {
+            let nd = to_process.pop_back();
+
+            if self.nodes[nd.index as usize].is_leaf() {
+                callback(nd);
+                continue;
+            }
+
+            let fc = self.nodes[nd.index as usize].get_first_child_node_index();
+
+            let octants = nd.crect.explore_octants_generic(element);
+            Self::collect_relevant_octants(&mut to_process, &nd, fc, octants, FindLeafHint::Query)
+        }
+    }
+
+    pub fn visit_leaves<F>(&self, mut visit: F)
+    where
+        F: FnMut(NodeInfo),
+    {
+        let mut to_process = NodeList::default();
+        to_process.push_back(self.get_root_node_data());
+
+        while !to_process.is_empty() {
+            let nd = to_process.pop_back();
+
+            let is_this_node = nd.index > 0 && ((nd.index - 1) % 9) == 0;
+            if is_this_node {
+                debug_assert!(self.nodes[nd.index as usize].is_leaf());
+                continue;
+            }
+
+            let node = &self.nodes[nd.index as usize];
+            if node.is_leaf() {
+                visit(NodeInfo::from(nd, node.element_count));
+                continue;
+            }
+
+            let fc = self.nodes[nd.index as usize].get_first_child_node_index();
+            Self::collect_relevant_octants(
+                &mut to_process,
+                &nd,
+                fc,
+                Octants::all(),
+                FindLeafHint::Query,
+            )
+        }
+    }
+
+    #[inline]
+    fn collect_relevant_octants(
+        to_process: &mut NodeList,
+        nd: &NodeData,
+        first_child_id: u32,
+        octants: Octants,
+        hint: FindLeafHint,
+    ) {
+        let split_octants = nd.crect.split_octants();
+
+        match hint {
+            FindLeafHint::Query => Self::collect_relevant_octants_for_query(
+                to_process,
+                nd.depth,
+                first_child_id,
+                octants,
+                &split_octants,
+            ),
+            FindLeafHint::Mutate => Self::collect_relevant_octants_for_mutation(
+                to_process,
+                nd.depth,
+                first_child_id,
+                octants,
+                &split_octants,
+            ),
+        }
+    }
+
+    fn collect_relevant_octants_for_mutation(
+        to_process: &mut NodeList,
+        depth: u8,
+        first_child_id: u32,
+        octants: Octants,
+        split_octants: &[CenteredAABB; 9],
+    ) {
+        let offset = octants.mutation_index();
+        debug_assert!(offset <= 8);
+
+        let can_split = offset > 0;
+
+        let child_depth = depth + (1 - octants.this() as u8);
+
+        to_process.push_back(NodeData::new(
+            split_octants[offset as usize],
+            first_child_id + offset,
+            child_depth,
+            can_split,
+        ));
+    }
+
+    fn collect_relevant_octants_for_query(
+        to_process: &mut NodeList,
+        depth: u8,
+        first_child_id: u32,
+        octants: Octants,
+        split_octants: &[CenteredAABB; 9],
+    ) {
+        let child_depth = depth + 1;
+
+        for offset in (1..=8).rev() {
+            if octants.at(offset as u32) {
+                to_process.push_back(NodeData::new(
+                    split_octants[offset as usize],
+                    first_child_id + offset,
+                    child_depth,
+                    true,
+                ));
+            }
+        }
+
+        to_process.push_back(NodeData::new(
+            split_octants[0],
+            first_child_id,
+            depth,
+            false,
+        ));
+    }
+
+    pub fn cleanup(&mut self) -> bool {
+        if self.nodes[0].is_leaf() {
+            return false;
+        }
+
+        let mut tree_compacted = false;
+        let mut to_process: SmallVec<[NodeIndexType; 128]> = smallvec::smallvec![0];
+
+        while let Some(node_index) = to_process.pop() {
+            let first_child_index = self.nodes[node_index as usize].get_first_child_node_index();
+
+            let mut num_empty_leaves = 0usize;
+            for j in 0..9 {
+                let child_index = first_child_index + j;
+                let child = &self.nodes[child_index as usize];
+
+                if child.is_empty() {
+                    num_empty_leaves += 1;
+                } else if child.is_branch() {
+                    to_process.push(child_index);
+                }
+            }
+
+            if num_empty_leaves == 9 {
+                self.nodes[first_child_index as usize].first_child_or_element = self.free_node;
+                self.free_node = first_child_index;
+
+                self.nodes[node_index as usize].make_empty_leaf();
+
+                tree_compacted = true;
+            }
+        }
+
+        tree_compacted
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn count_element_references(&self) -> usize {
+        let mut to_process: SmallVec<[usize; 128]> = smallvec::smallvec![0];
+        let mut count = 0usize;
+        while let Some(index) = to_process.pop() {
+            let node = &self.nodes[index];
+            if node.is_branch() {
+                for j in 0..9 {
+                    to_process.push((node.first_child_or_element + j) as usize);
+                }
+            } else {
+                count += node.element_count as usize;
+            }
+        }
+
+        debug_assert!(count >= self.element_ids.debug_len());
+        debug_assert!(count >= self.element_rects.debug_len());
+        count
+    }
+
+    #[inline]
+    fn get_root_node_data(&self) -> NodeData {
+        NodeData::new_from_root(&self.root_rect, true)
+    }
+
+    #[inline]
+    pub fn intersect_aabb(&self, rect: &AABB) -> Vec<ElementId> {
+        let root = self.get_root_node_data();
+        let mut node_set = Vec::with_capacity(128);
+
+        self.find_leaves_aabb_fn(root, rect, FindLeafHint::Query, |rect, nd| {
+            self.intersect_from_leaf(rect, nd, &mut |id| {
+                node_set.push(id);
+            });
+        });
+
+        node_set
+    }
+
+    #[inline]
+    pub fn intersect_aabb_fn<F>(&self, rect: &AABB, mut candidate_fn: F)
+    where
+        F: FnMut(ElementId),
+    {
+        let root = self.get_root_node_data();
+        self.find_leaves_aabb_fn(root, rect, FindLeafHint::Query, move |rect, nd| {
+            self.intersect_from_leaf(rect, nd, &mut |id| {
+                candidate_fn(id);
+            });
+        });
+    }
+
+    #[inline]
+    pub fn intersect_generic<T>(&self, element: &T) -> Vec<ElementId>
+    where
+        T: IntersectsWith<AABB>,
+    {
+        let root = self.get_root_node_data();
+        let mut node_set = Vec::with_capacity(128);
+
+        self.find_leaves_generic_fn(root, element, |nd| {
+            self.intersect_from_leaf(element, nd, &mut |id| {
+                node_set.push(id);
+            });
+        });
+
+        node_set
+    }
+
+    #[inline]
+    pub fn intersect_generic_fn<T, F>(&self, element: &T, mut candidate_fn: F)
+    where
+        T: IntersectsWith<AABB>,
+        F: FnMut(ElementId),
+    {
+        let root = self.get_root_node_data();
+        self.find_leaves_generic_fn(root, element, move |nd| {
+            self.intersect_from_leaf(element, nd, &mut |id| {
+                candidate_fn(id);
+            });
+        });
+    }
+
+    #[inline]
+    fn intersect_from_leaf<T, F>(&self, element: &T, leaf_data: NodeData, mut candidate_fn: F)
+    where
+        T: IntersectsWith<AABB>,
+        F: FnMut(ElementId),
+    {
+        let leaf = self.nodes[leaf_data.index as usize];
+        debug_assert!(leaf.is_leaf());
+
+        let mut elem_node_idx = leaf.first_child_or_element;
+        while elem_node_idx != free_list::SENTINEL {
+            let elem_node = unsafe { self.element_nodes.at(elem_node_idx) };
+            let elem_rect = unsafe { self.element_rects.at(elem_node.element_idx) };
+
+            if element.intersects_with(elem_rect) {
+                let elem_id = *unsafe { self.element_ids.at(elem_node.element_idx) };
+                candidate_fn(elem_id);
+            }
+
+            elem_node_idx = elem_node.next;
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn collect_ids(&self) -> Vec<ElementId> {
+        let aabb: AABB = self.root_rect.into();
+        self.intersect_aabb(&aabb)
+    }
+}
+
+impl<ElementId> Default for OctTree<ElementId>
+where
+    ElementId: ElementIdType,
+{
+    fn default() -> Self {
+        Self::new(OctRect::default(), 8, 16, 1)
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn build_test_tree() -> OctTree {
+    let oct_rect = OctRect::new(-20, -20, -20, 40, 40, 40);
+    let mut tree = OctTree::new(oct_rect, 1, 1, 1);
+
+    tree.insert(OctTreeElement::new(
+        1000,
+        AABB::new(-15, -15, -15, -5, -5, -5),
+    ))
+    .expect("insert should work");
+    tree.insert(OctTreeElement::new(
+        1001,
+        AABB::new(-20, -20, -20, -18, -18, -18),
+    ))
+    .expect("insert should work");
+
+    tree.insert(OctTreeElement::new(
+        2000,
+        AABB::new(5, -15, -15, 15, -5, -5),
+    ))
+    .expect("insert should work");
+
+    tree.insert(OctTreeElement::new(
+        3000,
+        AABB::new(-15, 5, -15, -5, 15, -5),
+    ))
+    .expect("insert should work");
+
+    tree.insert(OctTreeElement::new(4000, AABB::new(5, 5, -15, 15, 15, -5)))
+        .expect("insert should work");
+
+    tree.insert(OctTreeElement::new(5000, AABB::new(-5, -5, -5, 5, 5, 5)))
+        .expect("insert should work");
+
+    assert_eq!(tree.count_element_references(), 6);
+
+    let inserted_ids = tree.collect_ids();
+    assert_eq!(inserted_ids.len(), 6);
+    assert!(inserted_ids.contains(&1000));
+    assert!(inserted_ids.contains(&1001));
+    assert!(inserted_ids.contains(&2000));
+    assert!(inserted_ids.contains(&3000));
+    assert!(inserted_ids.contains(&4000));
+    assert!(inserted_ids.contains(&5000));
+
+    tree
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn cleanup_works() {
+        let oct_rect = OctRect::new(-20, -20, -20, 40, 40, 40);
+        let mut tree = OctTree::new(oct_rect, 1, 1, 1);
+
+        tree.insert(OctTreeElement::new(
+            1000,
+            AABB::new(-15, -15, -15, -5, -5, -5),
+        ))
+        .expect("insert should work");
+        tree.insert(OctTreeElement::new(
+            1001,
+            AABB::new(-20, -20, -20, -18, -18, -18),
+        ))
+        .expect("insert should work");
+        tree.insert(OctTreeElement::new(
+            2000,
+            AABB::new(5, -15, -15, 15, -5, -5),
+        ))
+        .expect("insert should work");
+        tree.insert(OctTreeElement::new(
+            3000,
+            AABB::new(-15, 5, -15, -5, 15, -5),
+        ))
+        .expect("insert should work");
+        tree.insert(OctTreeElement::new(4000, AABB::new(5, 5, -15, 15, 15, -5)))
+            .expect("insert should work");
+
+        assert_eq!(tree.collect_ids().len(), 5);
+
+        tree.insert(OctTreeElement::new(5000, AABB::new(-5, -5, -5, 5, 5, 5)))
+            .expect("insert should work");
+
+        assert_eq!(tree.collect_ids().len(), 6);
+        assert_eq!(tree.count_element_references(), 6);
+
+        assert!(tree.remove(&OctTreeElement::new(
+            1000,
+            AABB::new(-15, -15, -15, -5, -5, -5)
+        )));
+        assert!(tree.remove(&OctTreeElement::new(
+            1001,
+            AABB::new(-20, -20, -20, -18, -18, -18)
+        )));
+        assert!(tree.remove(&OctTreeElement::new(
+            2000,
+            AABB::new(5, -15, -15, 15, -5, -5)
+        )));
+        assert!(tree.remove(&OctTreeElement::new(
+            3000,
+            AABB::new(-15, 5, -15, -5, 15, -5)
+        )));
+        assert!(tree.remove(&OctTreeElement::new(4000, AABB::new(5, 5, -15, 15, 15, -5))));
+        assert!(tree.remove(&OctTreeElement::new(5000, AABB::new(-5, -5, -5, 5, 5, 5))));
+        assert_eq!(tree.collect_ids().len(), 0);
+        assert_eq!(tree.count_element_references(), 0);
+
+        assert!(tree.nodes[0].is_branch());
+        assert_eq!(tree.nodes[0].first_child_or_element, 1);
+
+        assert!(tree.cleanup());
+
+        assert!(tree.nodes[0].is_leaf());
+        assert_eq!(tree.nodes[0].element_count, 0);
+    }
+}

--- a/src/octree/octree_element.rs
+++ b/src/octree/octree_element.rs
@@ -1,0 +1,32 @@
+use crate::octree::{free_list, AABB};
+
+/// Alias for all traits required for an element ID.
+pub trait ElementIdType: Default + std::cmp::Eq + std::hash::Hash + Copy {}
+
+impl<T> ElementIdType for T where T: Default + std::cmp::Eq + std::hash::Hash + Copy {}
+
+/// Represents an element in the OctTree.
+#[derive(Debug, PartialEq, Eq, Default, Copy, Clone)]
+pub struct OctTreeElement<ElementId = u32>
+where
+    ElementId: ElementIdType,
+{
+    pub rect: AABB,
+    pub id: ElementId,
+}
+
+impl<ElementId> OctTreeElement<ElementId>
+where
+    ElementId: ElementIdType,
+{
+    pub fn new(id: ElementId, rect: AABB) -> Self {
+        Self { id, rect }
+    }
+}
+
+/// Represents an element node in the octree.
+#[derive(Debug, PartialEq, Eq, Default, Copy, Clone)]
+pub(crate) struct OctTreeElementNode {
+    pub next: free_list::IndexType,
+    pub element_idx: free_list::IndexType,
+}

--- a/src/octree/point.rs
+++ b/src/octree/point.rs
@@ -1,0 +1,22 @@
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub struct Point {
+    pub x: i32,
+    pub y: i32,
+    pub z: i32,
+}
+
+impl Point {
+    pub fn new(x: i32, y: i32, z: i32) -> Self {
+        Self { x, y, z }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn point_is_12_bytes() {
+        assert_eq!(std::mem::size_of::<Point>(), 12);
+    }
+}


### PR DESCRIPTION
This pull request introduces a new 3D spatial partitioning structure (`OctTree`) with full axis-aligned bounding box (AABB) support, public exports, and comprehensive unit tests. It also adds a new `RTree` implementation, extends benchmarks to compare QuadTree, RTree, and OctTree for both insertion and query performance, and includes new intersection and ray-casting tests and benchmarks. The changes are grouped into new features, benchmarking enhancements, and public API updates.

New spatial partitioning features:

* Introduced a 3D `OctTree` structure with support for 3D AABB queries, ray intersection, and generic intersection. Comprehensive unit tests cover insertion, intersection, ray casting, and cleanup scenarios (`src/octree.rs`, `src/octree/aabb.rs`, `src/octree/centered_aabb.rs`). [[1]](diffhunk://#diff-1ef6972a7654992d5b599d162a6d47256c400060443eebd69994f9c51d9a2db2R1-R143) [[2]](diffhunk://#diff-9d544651cbbc651126b5c4bd47c5c6b9b94570a9e38c559a81320c05dd1f2d2dR1-R152) [[3]](diffhunk://#diff-99c6aa0f1ed48d6c055f8826f2d13f2b366f8e2870a4cf651aa3ee6487135216R1-R218)
* Added a new `RTree` implementation with bounding box and ray intersection queries, and comparison benchmarks against QuadTree (`CHANGELOG.md`).

Benchmarking enhancements:

* Extended 3D benchmarks to include OctTree alongside QuadTree and RTree, covering inserts, AABB queries, and ray intersection scenarios (`benches/bench_compare_3d.rs`). [[1]](diffhunk://#diff-cf1b0540c57f4468dccb0de4f501c7266faa8f8f0b96804694aef5a5f11fca86R5-R18) [[2]](diffhunk://#diff-cf1b0540c57f4468dccb0de4f501c7266faa8f8f0b96804694aef5a5f11fca86R109-R135) [[3]](diffhunk://#diff-cf1b0540c57f4468dccb0de4f501c7266faa8f8f0b96804694aef5a5f11fca86R156-R172) [[4]](diffhunk://#diff-cf1b0540c57f4468dccb0de4f501c7266faa8f8f0b96804694aef5a5f11fca86R231-R259) [[5]](diffhunk://#diff-cf1b0540c57f4468dccb0de4f501c7266faa8f8f0b96804694aef5a5f11fca86R293-R309) [[6]](diffhunk://#diff-cf1b0540c57f4468dccb0de4f501c7266faa8f8f0b96804694aef5a5f11fca86R342-R357) [[7]](diffhunk://#diff-cf1b0540c57f4468dccb0de4f501c7266faa8f8f0b96804694aef5a5f11fca86R381-R397) [[8]](diffhunk://#diff-cf1b0540c57f4468dccb0de4f501c7266faa8f8f0b96804694aef5a5f11fca86R471-R482)

Public API updates:

* Exported `OctTree` and related types in the crate root, making them available for public use (`src/lib.rs`).

Please let me know if you want to dive into the implementation details or see how the benchmarks compare between the different spatial partitioning structures!